### PR TITLE
Feat: add produect id field to config.example.yml

### DIFF
--- a/configuration/application.go
+++ b/configuration/application.go
@@ -33,6 +33,7 @@ type AppConfig struct {
 
 type DataOrigin struct {
 	TimeFrame      TimeFrame `yaml:"timeFrame"`
+	ProductId      string    `yaml:"productId"`
 	ProductType    string    `yaml:"productType"`
 	StartTimestamp int64     `yaml:"startTimestamp"`
 	EndTimestamp   int64     `yaml:"endTimestamp"`

--- a/configuration/application_test.go
+++ b/configuration/application_test.go
@@ -20,6 +20,7 @@ func TestUnmarshal(t *testing.T) {
 	assert.Equal(t, "backTest", AppConfig.Task)
 	assert.Equal(t, configuration.DataOrigin{
 		TimeFrame:      configuration.TimeFrame{Seconds: 1},
+		ProductId:      "stock.aapl.us",
 		ProductType:    "stock",
 		StartTimestamp: 12345678,
 		EndTimestamp:   12345678,


### PR DESCRIPTION
구현하다 보니까 가장 중요한 필드를 빼먹었더라고요. product ID 필드를 config.yml에 추가합니다.