### PR TITLE
Fix: fix NotifiStop because a block occures in the if statement

### DIFF
--- a/internal/util/stop_notifier.go
+++ b/internal/util/stop_notifier.go
@@ -4,6 +4,13 @@ import (
 	"sync"
 )
 
+// closedchan is a reusable closed channel.
+var closedchan = make(chan struct{})
+
+func init() {
+	close(closedchan)
+}
+
 type StopNotifier struct {
 	mu sync.Mutex
 	ch chan struct{}
@@ -19,9 +26,7 @@ func (sn *StopNotifier) NotifyStop() {
 	sn.mu.Lock()
 	defer sn.mu.Unlock()
 
-	if _, ok := <-sn.ch; ok {
-		close(sn.ch)
-	}
+	sn.ch = closedchan
 }
 
 func (sn *StopNotifier) Done() chan struct{} {

--- a/internal/util/stop_notifier_test.go
+++ b/internal/util/stop_notifier_test.go
@@ -1,0 +1,69 @@
+package util_test
+
+import (
+	"testing"
+
+	"github.com/Goboolean/core-system.worker/internal/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(m *testing.M) {
+	m.Run()
+}
+
+func TestStopNotifier(t *testing.T) {
+	t.Run("Done함수를 호출하지 않았을 때 sn.Done()은 흐름을 block해야 한다.", func(t *testing.T) {
+
+		//arrange
+		//act
+		sn := util.NewStopNotifier()
+
+		//assert
+		assert.NotNil(t, sn)
+		assert.NotNil(t, sn.Done())
+		select {
+		case x := <-sn.Done():
+			t.Errorf("<-sn.Done() == %v, but it should block", x)
+		default:
+		}
+
+	})
+
+	t.Run("NotifyStop를 1회 호출했을때 sn.Done은 흐름을 block해야 한다.", func(t *testing.T) {
+
+		//arrange
+		sn := util.NewStopNotifier()
+		//act
+		sn.NotifyStop()
+		//assert
+		assert.NotNil(t, sn)
+		assert.NotNil(t, sn.Done())
+
+		select {
+		case <-sn.Done():
+		default:
+			t.Errorf("<-sn.Done() blocked, but it shuldn't block")
+		}
+
+	})
+
+	t.Run("NotifyStop를 2회(1회 초과) 호출했을때 sn.Done은 흐름을 block해야 한다.", func(t *testing.T) {
+
+		//arrange
+		sn := util.NewStopNotifier()
+		//act
+		sn.NotifyStop()
+		sn.NotifyStop()
+		//assert
+		assert.NotNil(t, sn)
+		assert.NotNil(t, sn.Done())
+
+		select {
+		case <-sn.Done():
+		default:
+			t.Errorf("<-sn.Done() blocked, but it shuldn't block")
+		}
+
+	})
+
+}


### PR DESCRIPTION
```go
	if _, ok := <-sn.ch; ok {
		close(sn.ch)
	}
```
if문에서 `_, ok := <-sn.ch;`이 전체 프로그램의 Block를 발생시키는 문제가 있었습니다. 원래 의도는 ok필드를 검사해 닫힌 채널인지 알아보고자 했던 것이었습니다. 그런데 해당 채널에 데이터가 들어오지 않으니 데이터가 들어올 때까지 대기하는 문제가 있었습니다. 이를 해결하기 위해 다른 방법을 사용했습니다.