### PR TITLE
Fix/joiner

### DIFF
--- a/internal/job/joiner/by_sequnce_num.go
+++ b/internal/job/joiner/by_sequnce_num.go
@@ -68,14 +68,19 @@ func (b *BySequnceNum) Execute() {
 				}
 
 				modelInputList.PushBack(modelDataPacket)
+
 			}
 
 			for e := modelInputList.Front(); e != nil; e = e.Next() {
 
+				if len(refanceInputBuf) == 0 {
+					break
+				}
+
 				location := findLargestPacketIndexBySequence(refanceInputBuf, e.Value.(model.Packet).Sequnce)
 
 				if refanceInputBuf[location].Sequnce != e.Value.(model.Packet).Sequnce {
-					break
+					continue
 				}
 
 				b.out <- model.Packet{
@@ -96,15 +101,34 @@ func (b *BySequnceNum) Execute() {
 
 // findLargestPacketIndexBySequence returns the index of the packet with the largest sequence number
 // that is less than or equal to the target sequence number.
+// -1 means all element has sequnce that is grater than target
+// WARINING: TO BE USED ONLY WITH ARRAYS SORTED IN ASCENDING ORDER
 func findLargestPacketIndexBySequence(data []model.Packet, target int64) int {
-	size := len(data)
-
-	i := 0
-	for i < size && data[i].Sequnce < target {
-		i++
+	// data는 순서가 보장돼 있고 대부분 앞 부분에 찾고자 하는 값이 있을 것이라
+	// 예상할 수 있으므로 순차탐색
+	sz := len(data)
+	if sz == 0 {
+		return -1
 	}
 
-	return i
+	first := data[0].Sequnce
+	last := data[sz-1].Sequnce
+
+	if first > target {
+		return -1
+	}
+
+	if last <= target {
+		return sz - 1
+	}
+
+	for i := 0; i < sz-1; i++ {
+		if data[i+1].Sequnce > target {
+			return i
+		}
+	}
+
+	return -2
 }
 
 func (b *BySequnceNum) Stop() error {

--- a/internal/job/joiner/by_sequnce_num_test.go
+++ b/internal/job/joiner/by_sequnce_num_test.go
@@ -14,8 +14,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestJoinBySequnceNum(t *testing.T) {
-	for i := 0; i < 10; i++ {
-		t.Run("Sequnce가 같은 두 데이터가 주어졌을 때, 이 두 데이터를 join해서 출력해야 한다.", func(t *testing.T) {
+	t.Run("Sequnce가 같은 두 데이터가 주어졌을 때, 이 두 데이터를 join해서 출력해야 한다.", func(t *testing.T) {
+
+		for i := 0; i < 100; i++ {
 			//arrange
 			refrenceInput := []model.Packet{
 				{
@@ -96,6 +97,7 @@ func TestJoinBySequnceNum(t *testing.T) {
 			}
 			//assert
 			assert.Equal(t, exp, output)
-		})
-	}
+		}
+	})
+
 }

--- a/internal/job/joiner/by_sequnce_num_test.go
+++ b/internal/job/joiner/by_sequnce_num_test.go
@@ -14,86 +14,88 @@ func TestMain(m *testing.M) {
 }
 
 func TestJoinBySequnceNum(t *testing.T) {
-	t.Run("Sequnce가 같은 두 데이터가 주어졌을 때, 이 두 데이터를 join해서 출력해야 한다.", func(t *testing.T) {
-		//arrange
-		refrenceInput := []model.Packet{
-			{
-				Sequnce: 1,
-				Data:    1,
-			},
-			{
-				Sequnce: 2,
-				Data:    1,
-			},
-			{
-				Sequnce: 3,
-				Data:    1,
-			},
-		}
-
-		modelInput := []model.Packet{
-
-			{
-				Sequnce: 2,
-				Data:    2,
-			},
-			{
-				Sequnce: 3,
-				Data:    2,
-			},
-		}
-
-		exp := []model.Packet{
-			{
-				Sequnce: 2,
-				Data: &model.Pair{
-					RefData:   1,
-					ModelData: 2,
+	for i := 0; i < 10; i++ {
+		t.Run("Sequnce가 같은 두 데이터가 주어졌을 때, 이 두 데이터를 join해서 출력해야 한다.", func(t *testing.T) {
+			//arrange
+			refrenceInput := []model.Packet{
+				{
+					Sequnce: 1,
+					Data:    1,
 				},
-			},
-			{
-				Sequnce: 3,
-				Data: &model.Pair{
-					RefData:   1,
-					ModelData: 2,
+				{
+					Sequnce: 2,
+					Data:    1,
 				},
-			},
-		}
-
-		refrenceInputChan := make(job.DataChan)
-		modelInputChan := make(job.DataChan)
-
-		go func() {
-			defer close(refrenceInputChan)
-			for _, e := range refrenceInput {
-				refrenceInputChan <- e
+				{
+					Sequnce: 3,
+					Data:    1,
+				},
 			}
-		}()
 
-		go func() {
-			defer close(modelInputChan)
-			for _, e := range modelInput {
-				modelInputChan <- e
+			modelInput := []model.Packet{
+
+				{
+					Sequnce: 2,
+					Data:    2,
+				},
+				{
+					Sequnce: 3,
+					Data:    2,
+				},
 			}
-		}()
 
-		joinner, err := joiner.NewBysequnce(&job.UserParams{})
-		if err != nil {
-			t.Error(err)
-			return
-		}
+			exp := []model.Packet{
+				{
+					Sequnce: 2,
+					Data: &model.Pair{
+						RefData:   1,
+						ModelData: 2,
+					},
+				},
+				{
+					Sequnce: 3,
+					Data: &model.Pair{
+						RefData:   1,
+						ModelData: 2,
+					},
+				},
+			}
 
-		joinner.SetRefInput(refrenceInputChan)
-		joinner.SetModelInput(modelInputChan)
-		outputChan := joinner.Output()
+			refrenceInputChan := make(job.DataChan)
+			modelInputChan := make(job.DataChan)
 
-		//act
-		output := make([]model.Packet, 0)
-		joinner.Execute()
-		for e := range outputChan {
-			output = append(output, e)
-		}
-		//assert
-		assert.Equal(t, exp, output)
-	})
+			go func() {
+				defer close(refrenceInputChan)
+				for _, e := range refrenceInput {
+					refrenceInputChan <- e
+				}
+			}()
+
+			go func() {
+				defer close(modelInputChan)
+				for _, e := range modelInput {
+					modelInputChan <- e
+				}
+			}()
+
+			joinner, err := joiner.NewBysequnce(&job.UserParams{})
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			joinner.SetRefInput(refrenceInputChan)
+			joinner.SetModelInput(modelInputChan)
+			outputChan := joinner.Output()
+
+			//act
+			output := make([]model.Packet, 0)
+			joinner.Execute()
+			for e := range outputChan {
+				output = append(output, e)
+			}
+			//assert
+			assert.Equal(t, exp, output)
+		})
+	}
 }


### PR DESCRIPTION
# 수정 이유

1. findLargestPacketIndexBySequence 함수에서 target으로 전달된 값이 data에 없을 때 data 슬라이스의 범위를 벗어난 값을 리턴하는 문제 해결
2. refanceInputBuf가 0일 때 findLargestPacketIndexBySequence를 호출해 배열의 범위를 벗어난 값을 리턴하는 문제 해결