### PR TITLE
Fix: Prevent channel returned by Done() from blocking after NotifyStop()

### DIFF
--- a/internal/util/stop_notifier_test.go
+++ b/internal/util/stop_notifier_test.go
@@ -66,4 +66,23 @@ func TestStopNotifier(t *testing.T) {
 
 	})
 
+	t.Run("NotifyStop을 호출했을 때 NotifyStop을 호출하기 전 Done에서 반환한 채널도 흐름을 block하지 않아야 한다.", func(t *testing.T) {
+
+		//arrange
+		sn := util.NewStopNotifier()
+		done := sn.Done()
+		//act
+		sn.NotifyStop()
+		sn.NotifyStop()
+		//assert
+		assert.NotNil(t, sn)
+		assert.NotNil(t, sn.Done())
+
+		select {
+		case <-done:
+		default:
+			t.Errorf("<-sn.Done() blocked, but it shouldn't block")
+		}
+
+	})
 }


### PR DESCRIPTION
Ensure that the channel returned by Done() does not remain blocked after NotifyStop() is called.

stop notifier를 사용할 때 NotifyStop()을 호출하기 전 Done()이 반환한 채널은 NotifyStop()이 호출되더라도 block이 풀리지 않는 문제가 있었습니다. 때문에 closed chan을 대입하는 방법이 아니라 sync.Once를 사용한 방법으로 다시 구현했습니다. context는 모든 작업을 수행하기 전 반드시 done인지 검사하기 때문에 이렇게 구현해도 괜찮으나 저희는 이렇게 구현하면 NotifyStop을 호출해도 신호를 받지 못하는 문제가 있네요.