### PR TITLE
Feat: pipeline stop notifier

### DIFF
--- a/internal/job/analyzer/stub.go
+++ b/internal/job/analyzer/stub.go
@@ -9,8 +9,6 @@ import (
 )
 
 type Stub struct {
-	Analyzer
-
 	in  job.DataChan
 	out job.DataChan
 
@@ -57,12 +55,6 @@ func (s *Stub) Execute() {
 
 		}
 	}()
-}
-
-func (s *Stub) Close() error {
-	s.sn.NotifyStop()
-	s.wg.Wait()
-	return nil
 }
 
 func (s *Stub) SetInput(in job.DataChan) {

--- a/internal/job/executer/interface.go
+++ b/internal/job/executer/interface.go
@@ -4,9 +4,16 @@ import (
 	"github.com/Goboolean/core-system.worker/internal/job"
 )
 
+// ModelExecutor represents an executor for a specific model job.
 type ModelExecutor interface {
 	job.Common
 
+	// SetInput sets the input data channel for the executor.
 	SetInput(job.DataChan)
+
+	// Output returns the output data channel for the executor.
 	Output() job.DataChan
+
+	// Cancel notifies the executor to immediately stop all currently running jobs.
+	Cancel()
 }

--- a/internal/job/executer/mock_model_exec.go
+++ b/internal/job/executer/mock_model_exec.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/Goboolean/core-system.worker/internal/infrastructure/kserve"
@@ -28,8 +27,6 @@ type Mock struct {
 
 	in  job.DataChan `type:""`
 	out job.DataChan `type:""` //Job은 자신의 Output 채널에 대해 소유권을 가진다.
-
-	wg sync.WaitGroup
 
 	stop *util.StopNotifier
 }
@@ -69,74 +66,66 @@ func NewMock(kServeClient kserve.Client, params *job.UserParams) (*Mock, error) 
 
 func (m *Mock) Execute() {
 
-	m.wg.Add(1)
 	go func() {
-		defer m.wg.Done()
 		defer m.stop.NotifyStop()
 		defer close(m.out)
 		var accumulator = make([]float32, 0)
 
-		for {
+		for input := range m.in {
+			//TODO: 고루틴이 무한정 생성되는 문제 해결
 			ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(1*60*time.Second))
 			go func() {
 				<-m.stop.Done()
 				cancel()
 			}()
 
-			select {
-			case input, ok := <-m.in:
-				if !ok {
-					//입력 채널이 닫혔을 때 처리
-					return
-				}
+			data, ok := input.Data.(*model.StockAggregate)
 
-				data, ok := input.Data.(*model.StockAggregate)
-
-				if !ok {
-					panic(fmt.Errorf("model exec job: type mismatch. expected *model.StockAggregate, got %s %w", reflect.TypeOf(input), job.ErrTypeMismatch))
-				}
-
-				//데이터를 1차원 텐서 타입으로 변환한다.
-				//데이터가 충분히 쌓일 때까지 다음 동작을 실행할 수 없도록 막는다.
-				var numOfInput = 4
-				accumulator = append(accumulator, data.High, data.Low, data.Open, data.Close)
-				if len(accumulator)/numOfInput < int(m.batchSize) {
-					continue
-				}
-
-				//이를 http client를 이용해 kserve로 보낸다.
-				var out []float32
-
-				b := backoff.WithMaxRetries(backoff.WithContext(backoff.NewExponentialBackOff(), ctx), uint64(m.maxRetry))
-
-				if err := backoff.Retry(func() error {
-					var err error
-					// Shape = [model.StockAggregate에서 사용되는 데이터의 개수 = 7, batch size]
-					out, err = m.kServeClient.RequestInference(ctx, []int{numOfInput, int(m.batchSize)}, accumulator)
-					return err
-
-				}, b); err != nil {
-					panic(fmt.Errorf("model exec job: inference service returns error %w", err))
-				}
-
-				accumulator = accumulator[numOfInput:]
-
-				//반환 받은 텐서 타입에서 알맞은 타입으로 가공한다.
-				//지금은 모델이 candlestick를 리턴한다고 가정한다.
-				//거래량 중요한 데이터가 아니므로 일단 0처리
-				m.out <- model.Packet{
-					Sequence: input.Sequence,
-					Data: &model.StockAggregate{
-						OpenTime:   data.ClosedTime,
-						ClosedTime: data.ClosedTime + (data.ClosedTime - data.OpenTime),
-						High:       out[0],
-						Low:        out[1],
-						Open:       out[2],
-						Close:      out[3],
-						Volume:     0.0,
-					},
-				}
+			if !ok {
+				panic(fmt.Errorf("model exec job: type mismatch. expected *model.StockAggregate, got %s %w", reflect.TypeOf(input), job.ErrTypeMismatch))
 			}
+
+			//데이터를 1차원 텐서 타입으로 변환한다.
+			//데이터가 충분히 쌓일 때까지 다음 동작을 실행할 수 없도록 막는다.
+			var numOfInput = 4
+			accumulator = append(accumulator, data.High, data.Low, data.Open, data.Close)
+			if len(accumulator)/numOfInput < int(m.batchSize) {
+				continue
+			}
+
+			//이를 http client를 이용해 kserve로 보낸다.
+			var out []float32
+
+			b := backoff.WithMaxRetries(backoff.WithContext(backoff.NewExponentialBackOff(), ctx), uint64(m.maxRetry))
+
+			if err := backoff.Retry(func() error {
+				var err error
+				// Shape = [model.StockAggregate에서 사용되는 데이터의 개수 = 7, batch size]
+				out, err = m.kServeClient.RequestInference(ctx, []int{numOfInput, int(m.batchSize)}, accumulator)
+				return err
+
+			}, b); err != nil {
+				panic(fmt.Errorf("model exec job: inference service returns error %w", err))
+			}
+
+			accumulator = accumulator[numOfInput:]
+
+			//반환 받은 텐서 타입에서 알맞은 타입으로 가공한다.
+			//지금은 모델이 candlestick를 리턴한다고 가정한다.
+			//거래량 중요한 데이터가 아니므로 일단 0처리
+			m.out <- model.Packet{
+				Sequence: input.Sequence,
+				Data: &model.StockAggregate{
+					OpenTime:   data.ClosedTime,
+					ClosedTime: data.ClosedTime + (data.ClosedTime - data.OpenTime),
+					High:       out[0],
+					Low:        out[1],
+					Open:       out[2],
+					Close:      out[3],
+					Volume:     0.0,
+				},
+			}
+
 		}
 	}()
 
@@ -150,8 +139,6 @@ func (m *Mock) Output() job.DataChan {
 	return m.out
 }
 
-func (m *Mock) Close() error {
+func (m *Mock) Cancel() {
 	m.stop.NotifyStop()
-	m.wg.Wait()
-	return nil
 }

--- a/internal/job/executer/stub.go
+++ b/internal/job/executer/stub.go
@@ -9,8 +9,6 @@ import (
 )
 
 type Stub struct {
-	ModelExecutor
-
 	in  job.DataChan `type:""`
 	out job.DataChan `type:""` //Job은 자신의 Output 채널에 대해 소유권을 가진다.
 
@@ -75,8 +73,6 @@ func (m *Stub) Output() job.DataChan {
 	return m.out
 }
 
-func (m *Stub) Close() error {
+func (m *Stub) Cancel() {
 	m.stop.NotifyStop()
-	m.wg.Wait()
-	return nil
 }

--- a/internal/job/fetcher/fetch_past_stock.go
+++ b/internal/job/fetcher/fetch_past_stock.go
@@ -20,8 +20,6 @@ var (
 )
 
 type PastStock struct {
-	Fetcher
-
 	timeSlice           string
 	isFetchingFullRange bool
 	startTimestamp      int64 // Unix timestamp of start time
@@ -136,8 +134,7 @@ func (ps *PastStock) Output() job.DataChan {
 	return ps.out
 }
 
-func (ps *PastStock) Close() error {
+func (ps *PastStock) Stop() {
 	ps.stop.NotifyStop()
 	ps.wg.Wait()
-	return nil
 }

--- a/internal/job/fetcher/fetch_realtime_stock.go
+++ b/internal/job/fetcher/fetch_realtime_stock.go
@@ -13,8 +13,6 @@ import (
 )
 
 type RealtimeStock struct {
-	Fetcher
-
 	pastRepo mongo.StockClient
 
 	//미리 가져올 데이터의 개수
@@ -22,7 +20,8 @@ type RealtimeStock struct {
 	timeSlice   string
 	stockID     string
 
-	out  job.DataChan `type:"*StockAggregate"` //Job은 자신의 Output 채널에 대해 소유권을 가진다.
+	out job.DataChan `type:"*StockAggregate"` //Job은 자신의 Output 채널에 대해 소유권을 가진다.
+
 	wg   sync.WaitGroup
 	stop *util.StopNotifier
 }
@@ -107,8 +106,7 @@ func (rt *RealtimeStock) Output() job.DataChan {
 	return rt.out
 }
 
-func (rt *RealtimeStock) Close() error {
+func (rt *RealtimeStock) Stop() {
 	rt.stop.NotifyStop()
 	rt.wg.Wait()
-	return nil
 }

--- a/internal/job/fetcher/interface.go
+++ b/internal/job/fetcher/interface.go
@@ -9,12 +9,15 @@ import (
 	"github.com/Goboolean/core-system.worker/internal/job"
 )
 
-// Fetcher is an interface that represents a job fetcher.
+// Fetcher represents a job fetcher that retrieves trade data.
 type Fetcher interface {
 	job.Common
 
 	// Output returns the data channel for the fetched trade data.
 	Output() job.DataChan
+
+	// Stop stops the fetcher and releases any allocated resources.
+	Stop()
 }
 
 // FetchingSession is an interface that represents a fetching session.

--- a/internal/job/fetcher/stock_stub.go
+++ b/internal/job/fetcher/stock_stub.go
@@ -13,8 +13,6 @@ import (
 )
 
 type StockStub struct {
-	Fetcher
-
 	numOfGeneration            int
 	maxRandomDelayMilliseconds int
 
@@ -97,8 +95,7 @@ func (ps *StockStub) Output() job.DataChan {
 	return ps.out
 }
 
-func (ps *StockStub) Close() error {
+func (ps *StockStub) Stop() {
 	ps.stop.NotifyStop()
 	ps.wg.Wait()
-	return nil
 }

--- a/internal/job/interface.go
+++ b/internal/job/interface.go
@@ -4,7 +4,4 @@ package job
 type Common interface {
 	// Execute executes the job.
 	Execute()
-
-	// Close stops job and cleans infra of job and returns an error if any.
-	Close() error
 }

--- a/internal/job/joiner/by_sequnce_num.go
+++ b/internal/job/joiner/by_sequnce_num.go
@@ -2,42 +2,30 @@ package joiner
 
 import (
 	"container/list"
-	"sync"
 
 	"github.com/Goboolean/core-system.worker/internal/job"
 	"github.com/Goboolean/core-system.worker/internal/model"
-	"github.com/Goboolean/core-system.worker/internal/util"
 )
 
 // BySequenceNum는 model.Packet에 있는 sequnce값이 같은 두 데이터를 Pair에 담아 출력합니다.
 type BySequenceNum struct {
-	Joiner
-
 	refIn   job.DataChan
 	modelIn job.DataChan
 	out     job.DataChan
-
-	wg   sync.WaitGroup
-	stop *util.StopNotifier
 }
 
 func NewBySequence(params *job.UserParams) (*BySequenceNum, error) {
 
 	instance := &BySequenceNum{
-		out:  make(job.DataChan),
-		wg:   sync.WaitGroup{},
-		stop: util.NewStopNotifier(),
+		out: make(job.DataChan),
 	}
 
 	return instance, nil
 }
 
 func (b *BySequenceNum) Execute() {
-	b.wg.Add(1)
 	go func() {
-		defer b.wg.Done()
 		defer close(b.out)
-		defer b.stop.NotifyStop()
 
 		referenceInputBuf := make([]model.Packet, 0, 100)
 		modelInputList := list.New()
@@ -51,9 +39,6 @@ func (b *BySequenceNum) Execute() {
 			}
 
 			select {
-
-			case <-b.stop.Done():
-				return
 			case referenceDataPacket, ok := <-b.refIn:
 				if !ok {
 					refInChanFail = true
@@ -127,12 +112,6 @@ func findLargestPacketIndexBySequence(data []model.Packet, target int64) int {
 	}
 
 	return -2
-}
-
-func (b *BySequenceNum) Stop() error {
-	b.stop.NotifyStop()
-	b.wg.Wait()
-	return nil
 }
 
 func (b *BySequenceNum) SetRefInput(in job.DataChan) {

--- a/internal/job/transmitter/fake.go
+++ b/internal/job/transmitter/fake.go
@@ -1,8 +1,6 @@
 package transmitter
 
 import (
-	"sync"
-
 	"github.com/Goboolean/core-system.worker/internal/job"
 	"github.com/Goboolean/core-system.worker/internal/model"
 	"github.com/Goboolean/core-system.worker/internal/util"
@@ -11,33 +9,23 @@ import (
 
 // Execute executes the job with the given context.
 type Fake struct {
-	Transmitter
-
 	in job.DataChan
 
-	wg *sync.WaitGroup
-	sn *util.StopNotifier
+	done *util.StopNotifier
 }
 
 func NewFake() (*Fake, error) {
 	return &Fake{
-		wg: &sync.WaitGroup{},
-		sn: util.NewStopNotifier(),
+		done: util.NewStopNotifier(),
 	}, nil
 
 }
 
 func (f *Fake) Execute() {
-	f.wg.Add(1)
 
 	go func() {
-		defer f.wg.Done()
-		select {
-		case <-f.sn.Done():
-		case in, ok := <-f.in:
-			if !ok {
-				return
-			}
+		defer f.done.NotifyStop()
+		for in := range f.in {
 
 			orderEvent := in.Data.(*model.OrderEvent)
 
@@ -52,12 +40,10 @@ func (f *Fake) Execute() {
 	}()
 }
 
-func (f *Fake) Close() error {
-	f.sn.NotifyStop()
-	f.wg.Wait()
-	return nil
-}
-
 func (f *Fake) SetInput(in job.DataChan) {
 	f.in = in
+}
+
+func (f *Fake) Done() chan struct{} {
+	return f.done.Done()
 }

--- a/internal/job/transmitter/interface.go
+++ b/internal/job/transmitter/interface.go
@@ -6,10 +6,14 @@ import (
 	"github.com/Goboolean/core-system.worker/internal/job"
 )
 
-// Transmitter is an interface that represents a job transmitter.
+// Transmitter represents a job transmitter that sends data to a specific destination.
 type Transmitter interface {
 	job.Common
 
 	// SetInput sets the input data channel for the transmitter.
 	SetInput(job.DataChan)
+
+	// Done returns a channel that is closed when the transmitter has completed all its tasks
+	// and cleaned up the given infrastructure.
+	Done() chan struct{}
 }

--- a/internal/job/transmitter/v1/common_test.go
+++ b/internal/job/transmitter/v1/common_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/Goboolean/core-system.worker/internal/job"
 	"github.com/Goboolean/core-system.worker/internal/job/transmitter"
@@ -66,7 +65,10 @@ func TestCommon(t *testing.T) {
 		mockAnnotationDispatcher := transmitter.NewMockAnnotationDispatcher(ctrl)
 
 		mockOrderEventDispatcher.EXPECT().Dispatch(gomock.Any()).Times(numOrder)
+		mockOrderEventDispatcher.EXPECT().Close().AnyTimes()
+
 		mockAnnotationDispatcher.EXPECT().Dispatch(gomock.Any()).Times(numAnnotation)
+		mockAnnotationDispatcher.EXPECT().Close().AnyTimes()
 
 		transmit, err := v1.NewCommon(mockAnnotationDispatcher, mockOrderEventDispatcher, &job.UserParams{
 			"productID": "test.product",
@@ -80,9 +82,8 @@ func TestCommon(t *testing.T) {
 
 		//act
 		transmit.Execute()
-		for len(inChan) > 0 {
-			time.Sleep(250 * time.Millisecond)
-		}
+		<-transmit.Done()
+
 		assert.NoError(t, err)
 	})
 }

--- a/internal/pipeline/interface.go
+++ b/internal/pipeline/interface.go
@@ -2,5 +2,7 @@ package pipeline
 
 type Pipeline interface {
 	Run()
-	Stop() error
+	Stop()
+
+	Done() chan struct{}
 }

--- a/internal/pipeline/interface.go
+++ b/internal/pipeline/interface.go
@@ -1,8 +1,10 @@
 package pipeline
 
+// Pipeline represents a pipeline that can be run and stopped.
 type Pipeline interface {
 	Run()
 	Stop()
 
+	// Done returns a channel that is closed when all jobs in the pipeline have completed.
 	Done() chan struct{}
 }

--- a/internal/pipeline/normal.go
+++ b/internal/pipeline/normal.go
@@ -2,7 +2,6 @@ package pipeline
 
 import (
 	"errors"
-	"fmt"
 	"reflect"
 
 	"github.com/Goboolean/core-system.worker/internal/job"
@@ -96,25 +95,14 @@ func (n *Normal) Run() {
 	n.joiner.Execute()
 	n.resAnalyzer.Execute()
 	n.transmitter.Execute()
+
 }
 
-func (n *Normal) Stop() error {
+func (n *Normal) Stop() {
+	n.fetcher.Stop()
+	n.modelExecuter.Cancel()
+}
 
-	if err := n.fetcher.Close(); err != nil {
-		return fmt.Errorf("pipeline: failed to shutdown fetch job %w", err)
-	}
-	if err := n.modelExecuter.Close(); err != nil {
-		return fmt.Errorf("pipeline: failed to shutdown model execute job %w", err)
-	}
-	if err := n.adapter.Close(); err != nil {
-		return fmt.Errorf("pipeline: failed to shutdown adapt job %w", err)
-	}
-	if err := n.resAnalyzer.Close(); err != nil {
-		return fmt.Errorf("pipeline: failed to shutdown analyze job %w", err)
-	}
-	if err := n.transmitter.Close(); err != nil {
-		return fmt.Errorf("pipeline: failed to shutdown transmit job %w", err)
-	}
-
-	return nil
+func (n *Normal) Done() chan struct{} {
+	return n.transmitter.Done()
 }

--- a/internal/pipeline/normal.go
+++ b/internal/pipeline/normal.go
@@ -101,6 +101,8 @@ func (n *Normal) Run() {
 func (n *Normal) Stop() {
 	n.fetcher.Stop()
 	n.modelExecuter.Cancel()
+
+	<-n.transmitter.Done()
 }
 
 func (n *Normal) Done() chan struct{} {

--- a/internal/pipeline/without_model.go
+++ b/internal/pipeline/without_model.go
@@ -66,6 +66,7 @@ func (wom *WithoutModel) Run() {
 
 func (wom *WithoutModel) Stop() {
 	wom.fetcher.Stop()
+	<-wom.transmitter.Done()
 }
 
 func (wom *WithoutModel) Done() chan struct{} {

--- a/internal/pipeline/without_model.go
+++ b/internal/pipeline/without_model.go
@@ -1,7 +1,6 @@
 package pipeline
 
 import (
-	"fmt"
 	"reflect"
 
 	"github.com/Goboolean/core-system.worker/internal/job/adapter"
@@ -65,20 +64,10 @@ func (wom *WithoutModel) Run() {
 
 }
 
-func (wom *WithoutModel) Stop() error {
+func (wom *WithoutModel) Stop() {
+	wom.fetcher.Stop()
+}
 
-	if err := wom.fetcher.Close(); err != nil {
-		return fmt.Errorf("pipeline: failed to shutdown fetch job %w", err)
-	}
-	if err := wom.adapter.Close(); err != nil {
-		return fmt.Errorf("pipeline: failed to shutdown adapt job %w", err)
-	}
-	if err := wom.analyzer.Close(); err != nil {
-		return fmt.Errorf("pipeline: failed to shutdown analyze job %w", err)
-	}
-	if err := wom.transmitter.Close(); err != nil {
-		return fmt.Errorf("pipeline: failed to shutdown transmit job %w", err)
-	}
-
-	return nil
+func (wom *WithoutModel) Done() chan struct{} {
+	return wom.transmitter.Done()
 }


### PR DESCRIPTION
# 수정 상황 요약

## 중요

- 파이프라인의 Stop이 이제부터 비동기적으로 처리됩니다.
- 파이프라인의 모든 job이 종료됐을 때 닫히는 채널을 반환하는 Done()이 추가됐습니다.

## 기타

- 이제부터 Job의 Stop, Cancel과 같은 함수는 비동기적으로 작동합니다.
- Transmitter 인터페이스에 Done()을 추가했습니다.
