### PR TITLE
Feat: introduce generic to channel mux

### DIFF
--- a/internal/job/channel_mux.go
+++ b/internal/job/channel_mux.go
@@ -1,21 +1,21 @@
 package job
 
-type ChannelMux struct {
-	in  DataChan
-	out []DataChan
+type ChannelMux[T any] struct {
+	in  chan T
+	out []chan T
 }
 
-func (fo *ChannelMux) SetInput(in DataChan) {
+func (fo *ChannelMux[T]) SetInput(in chan T) {
 	fo.in = in
 }
 
-func (fo *ChannelMux) Output() DataChan {
-	ch := make(DataChan, 1)
+func (fo *ChannelMux[T]) Output() chan T {
+	ch := make(chan T, 1)
 	fo.out = append(fo.out, ch)
 	return ch
 }
 
-func (fo *ChannelMux) Execute() {
+func (fo *ChannelMux[T]) Execute() {
 	go func() {
 		defer func() {
 			for _, ch := range fo.out {

--- a/internal/pipeline/normal.go
+++ b/internal/pipeline/normal.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/Goboolean/core-system.worker/internal/job"
 	"github.com/Goboolean/core-system.worker/internal/job/adapter"
 	"github.com/Goboolean/core-system.worker/internal/job/analyzer"
 	"github.com/Goboolean/core-system.worker/internal/job/executer"
@@ -13,6 +12,7 @@ import (
 	"github.com/Goboolean/core-system.worker/internal/job/joiner"
 	"github.com/Goboolean/core-system.worker/internal/job/transmitter"
 	"github.com/Goboolean/core-system.worker/internal/model"
+	"github.com/Goboolean/core-system.worker/internal/util"
 )
 
 var ErrTypeNotMatch = errors.New("pipeline: cannot build a pipeline because the types are not compatible between the jobs")
@@ -28,7 +28,7 @@ type Normal struct {
 	transmitter   transmitter.Transmitter
 
 	//utils
-	mux job.ChannelMux[model.Packet]
+	mux util.ChannelMux[model.Packet]
 }
 
 func newNormalWithAdapter(
@@ -47,7 +47,7 @@ func newNormalWithAdapter(
 		resAnalyzer:   resAnalyzer,
 		transmitter:   transmitter,
 
-		mux: job.ChannelMux[model.Packet]{},
+		mux: util.ChannelMux[model.Packet]{},
 	}
 
 	instance.mux.SetInput(instance.fetcher.Output())

--- a/internal/pipeline/normal.go
+++ b/internal/pipeline/normal.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Goboolean/core-system.worker/internal/job/fetcher"
 	"github.com/Goboolean/core-system.worker/internal/job/joiner"
 	"github.com/Goboolean/core-system.worker/internal/job/transmitter"
+	"github.com/Goboolean/core-system.worker/internal/model"
 )
 
 var ErrTypeNotMatch = errors.New("pipeline: cannot build a pipeline because the types are not compatible between the jobs")
@@ -27,7 +28,7 @@ type Normal struct {
 	transmitter   transmitter.Transmitter
 
 	//utils
-	mux job.ChannelMux
+	mux job.ChannelMux[model.Packet]
 }
 
 func newNormalWithAdapter(
@@ -46,7 +47,7 @@ func newNormalWithAdapter(
 		resAnalyzer:   resAnalyzer,
 		transmitter:   transmitter,
 
-		mux: job.ChannelMux{},
+		mux: job.ChannelMux[model.Packet]{},
 	}
 
 	instance.mux.SetInput(instance.fetcher.Output())

--- a/internal/util/channel_mux.go
+++ b/internal/util/channel_mux.go
@@ -1,4 +1,4 @@
-package job
+package util
 
 type ChannelMux[T any] struct {
 	in  chan T


### PR DESCRIPTION
채널 먹스는 유틸리티 성격이 강하기 때문에 범용적인 타입에 대응될 필요가 있어 보입니다. Job과 Job 사이가 아니라 어디서든지 사용될 수 있어서 다양한 타입에 대응돼야 할 것 같아요. 이렇게 변경되면 job에 종속되는 개념이 아니라서 util로 패키지를 이동해야 할 것 같습니다.