### PR TITLE
Fix: fix issue when creating Normal pipeline without adapter

### DIFF
--- a/internal/pipeline/normal.go
+++ b/internal/pipeline/normal.go
@@ -73,6 +73,7 @@ func newNormalWithoutAdapter(
 		joiner:        join,
 		resAnalyzer:   resAnalyze,
 		transmitter:   transmit,
+		mux:           util.NewChannelMux[model.Packet](),
 	}
 
 	instance.mux.SetInput(instance.fetcher.Output())


### PR DESCRIPTION
newNormalWithoutAdapter()에서 mux가 초기화 안 돼 세그멘테이션 에러 발생하는 경우가 있습니다. 