### PR TITLE
Chore: Rearrange TradeRepository interface methods

### DIFF
--- a/internal/job/fetcher/fetch_past_stock.go
+++ b/internal/job/fetcher/fetch_past_stock.go
@@ -101,9 +101,9 @@ func (ps *PastStock) Execute() {
 			cancel()
 		}()
 
-		ps.pastRepo.SelectProduct(ps.stockID, ps.timeSlice, "stock")
+		ps.pastRepo.SelectProduct(ps.stockID, ps.timeSlice)
 		ps.pastRepo.SetRangeByTime(ps.startTime, ps.endTime)
-		session, err := ps.pastRepo.Session()
+		session, err := ps.pastRepo.ExecuteQuery(ctx)
 		if err != nil {
 			panic(err)
 		}
@@ -112,7 +112,7 @@ func (ps *PastStock) Execute() {
 			b := backoff.WithContext(backoff.NewExponentialBackOff(), ctx)
 
 			if err := backoff.Retry(func() error {
-				v, err := session.Value(ctx)
+				v, err := session.Value()
 				if err != nil {
 					return err
 				}

--- a/internal/job/fetcher/interface.go
+++ b/internal/job/fetcher/interface.go
@@ -35,12 +35,12 @@ type TradeCursor interface {
 
 	// Value returns the current item in the fetching session.
 	// It returns the item and an error if there was an error retrieving the item.
-	Value(ctx context.Context) (any, error)
+	Value() (any, error)
 }
 
 type TradeRepository interface {
 	// SelectProduct selects a product by ID, time frame, and product type.
-	SelectProduct(ID string, timeFrame string, productType string)
+	SelectProduct(ID string, timeFrame string)
 
 	// SetRangeByTime sets the time range for trade data.
 	SetRangeByTime(from time.Time, to time.Time)
@@ -52,9 +52,9 @@ type TradeRepository interface {
 	// that were created just before the given end time,
 	SetRangeByNumberAndEndTime(num int, end time.Time)
 
-	// Session returns a fetching session.
-	// Before you call session, you must select product and set range
-	Session() (TradeCursor, error)
+	// ExecuteQuery executes the query and returns a TradeCursor, allowing access to each data item sequentially.
+	// Before calling ExecuteQuery, you MUST select a product and set its range.
+	ExecuteQuery(ctx context.Context) (TradeCursor, error)
 
 	// Close closes the connection
 	Close() error
@@ -65,7 +65,7 @@ type TradeStream interface {
 	SelectProduct(ID string, timeFrame string, productType string)
 
 	// Session returns a fetching session.
-	// Before you call session, you must select product.
+	// Before you call session, you MUST select product.
 	Session() (TradeCursor, error)
 
 	// Close closes the connection.


### PR DESCRIPTION
- Moved context.Context parameter to ExecuteQuery method for improved handling
- Clarified SelectProduct method to handle product selection and time frame setting more clearly

대부분 db의 golang driver에서 value를 가져오는 데는 context를 요구하지 않고 쿼리를 실행하는 데 context를 요구합니다.(mongodb 예외) 아마 데이터를 실제 가져오는 것보다 데이터를 가져오기 전에 준비하는 시간이 상당히 긴 것이 그 원인인 것 같습니다. 따라서 이에 맞게 fetcher 인터페이스를 수정합니다. 