### PR TITLE
Fix test script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,4 @@ wire-job:
 	wire ${STAGE_PACKAGES}
 
 test:
-	go test ./...
+	go test ./... -tags develop


### PR DESCRIPTION
# 수정 이유

일부 테스트용 컴포넌트가 CI 테스트시 포함되지 않는 문제를 수정하기 위해 테스트 스크립트에 tag 옵션을 줬습니다.