### PR TITLE
Fix: fix fetcher not to return ctx canceled error

### DIFF
--- a/internal/job/fetcher/fetch_past_stock.go
+++ b/internal/job/fetcher/fetch_past_stock.go
@@ -104,11 +104,12 @@ func (ps *PastStock) Execute() error {
 	}
 
 	for {
+		e, err := ps.cursor.Next(ctx)
+
 		select {
 		case <-ps.stop.Done():
 			return nil
 		default:
-			e, err := ps.cursor.Next(ctx)
 			if e == nil {
 				return nil
 			}


### PR DESCRIPTION
Fetcher의 NotifyStop이 호출됐을 때 context를 바로 cancel해버리는데 이때 influxdb에서 에러를 반환해서 비정상 종료로 인식되는 문제가 있습니다.  